### PR TITLE
Annotate backend rust to generate an openapi endpoint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,3 +48,9 @@ jobs:
 
     - name: Lint with rustfmt
       run: cargo fmt -- --check
+
+    - name: Generate OpenAPI documentation
+      run: cargo run --bin bidding_app > openapi_generated.json
+
+    - name: Compare OpenAPI documentation
+      run: diff -q openapi_generated.json openapi.json || (echo "OpenAPI documentation is not up to date" && exit 1)

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,6 +19,8 @@ dotenvy = "0.15.7"
 tokio-pg-mapper = "0.2.0"
 derive_more = { version = "1.0.0", features = ["display", "error", "from"] }
 tokio-pg-mapper-derive = "0.2.0"
+utoipa = "5.2.0"
+utoipa-swagger-ui = "8.0.3"
 
 [[bin]]
 name = "bidding_app"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -20,7 +20,7 @@ tokio-pg-mapper = "0.2.0"
 derive_more = { version = "1.0.0", features = ["display", "error", "from"] }
 tokio-pg-mapper-derive = "0.2.0"
 utoipa = "5.2.0"
-utoipa-swagger-ui = { "8.0.3", features = ["actix-web"] }
+utoipa-swagger-ui = { version = "8.0.3", features = ["actix-web"] }
 
 [[bin]]
 name = "bidding_app"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -20,7 +20,7 @@ tokio-pg-mapper = "0.2.0"
 derive_more = { version = "1.0.0", features = ["display", "error", "from"] }
 tokio-pg-mapper-derive = "0.2.0"
 utoipa = "5.2.0"
-utoipa-swagger-ui = "8.0.3"
+utoipa-swagger-ui = { "8.0.3", features = ["actix-web"] }
 
 [[bin]]
 name = "bidding_app"

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -24,3 +24,6 @@ test:
 update-deps:
 	cargo upgrade -i allow && cargo update
 
+# Generate OpenAPI documentation
+generate-openapi:
+	cargo run --bin bidding_app > openapi_generated.json

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -7,6 +7,8 @@ pub struct ServiceConfig {
     pub server_addr: String,
     #[confik(from = DbConfig)]
     pub pg: deadpool_postgres::Config,
+    #[confik(default = "fake_pg")]
+    pub fake_pg: deadpool_postgres::Config,
 }
 
 #[derive(Debug, Deserialize)]
@@ -21,4 +23,13 @@ impl From<DbConfig> for deadpool_postgres::Config {
 
 impl confik::Configuration for DbConfig {
     type Builder = Option<Self>;
+}
+
+fn fake_pg() -> deadpool_postgres::Config {
+    deadpool_postgres::Config {
+        user: Some("fake_user".to_string()),
+        password: Some("fake_password".to_string()),
+        dbname: Some("fake_db".to_string()),
+        ..Default::default()
+    }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -36,7 +36,7 @@ pub async fn add_user(
 }
 
 #[actix_web::main]
-async fn main() -> std::.io::Result<()> {
+async fn main() -> std::io::Result<()> {
     dotenv().ok();
     let docs_mode = std::env::var("DOCS_MODE").unwrap_or_else(|_| "false".to_string()) == "true";
     let config = ServiceConfig::builder()

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -54,9 +54,7 @@ async fn main() -> std::io::Result<()> {
                     .route(web::post().to(add_user))
                     .route(web::get().to(get_users)),
             )
-            .service(
-                SwaggerUi::new("/api-docs").url("/api-docs/openapi.json", ApiDoc::openapi())
-            )
+            .service(SwaggerUi::new("/api-docs").url("/api-docs/openapi.json", ApiDoc::openapi()))
     })
     .bind(config.server_addr.clone())?
     .run();

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -5,13 +5,17 @@ use deadpool_postgres::{Client, Pool};
 use dotenvy::dotenv;
 use env_logger::Env;
 use tokio_postgres::NoTls;
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
 
 use crate::config::ServiceConfig;
+use crate::openapi::ApiDoc;
 
 mod config;
 mod db;
 mod errors;
 mod models;
+mod openapi;
 
 use self::{errors::MyError, models::User};
 
@@ -49,6 +53,9 @@ async fn main() -> std::io::Result<()> {
                 web::resource("/users")
                     .route(web::post().to(add_user))
                     .route(web::get().to(get_users)),
+            )
+            .service(
+                SwaggerUi::new("/api-docs").url("/api-docs/openapi.json", ApiDoc::openapi())
             )
     })
     .bind(config.server_addr.clone())?

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use tokio_pg_mapper_derive::PostgresMapper;
+use utoipa::ToSchema;
 
-#[derive(Deserialize, PostgresMapper, Serialize)]
+#[derive(Deserialize, PostgresMapper, Serialize, ToSchema)]
 #[pg_mapper(table = "users")] // singular 'user' is a keyword..
 pub struct User {
     pub email: String,

--- a/backend/src/openapi.rs
+++ b/backend/src/openapi.rs
@@ -1,0 +1,7 @@
+use utoipa::OpenApi;
+
+use crate::models::User;
+
+#[derive(OpenApi)]
+#[openapi(paths(), components(schemas(User)))]
+pub struct ApiDoc;


### PR DESCRIPTION
Add OpenAPI annotations and generate OpenAPI endpoint documentation.

* Add `utoipa` and `utoipa-swagger-ui` dependencies to `backend/Cargo.toml`.
* Annotate `User` struct in `backend/src/models.rs` with `utoipa::ToSchema` derive macro.
* Create `backend/src/openapi.rs` to define OpenAPI specification using `utoipa::OpenApi`.
* Update `backend/src/main.rs` to serve OpenAPI documentation and Swagger UI.
* Add OpenAPI endpoint `/api-docs` to `backend/src/main.rs`.
* Add a documentation check step in the `.github/workflows/rust.yml` file to generate the documentation and compare it with the existing documentation.
* Add an entry in the `backend/Makefile` to generate the OpenAPI documentation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tomMoulard/Yes/pull/4?shareId=6f5d1fb1-a3d7-4a78-91f6-e252a0b7e900).