### PR TITLE
Enable tracing for Rust backend

### DIFF
--- a/.devcontainers/docker-compose.yml
+++ b/.devcontainers/docker-compose.yml
@@ -11,5 +11,25 @@ services:
       # - postgres_data:/var/lib/postgresql/data
       - ./fixtures/:/docker-entrypoint-initdb.d/
 
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    ports:
+      - "4317:4317"
+      - "55680:55680"
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    command: ["--config", "/etc/otel-collector-config.yaml"]
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "6831:6831/udp"
+      - "6832:6832/udp"
+      - "5778:5778"
+      - "16686:16686"
+      - "14250:14250"
+      - "14268:14268"
+      - "14269:14269"
+
 volumes:
   postgres_data:

--- a/.devcontainers/otel-collector-config.yaml
+++ b/.devcontainers/otel-collector-config.yaml
@@ -1,0 +1,19 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  logging:
+    loglevel: debug
+  jaeger:
+    endpoint: "http://jaeger:14250"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [logging, jaeger]

--- a/backend/.env.dev
+++ b/backend/.env.dev
@@ -1,1 +1,2 @@
 PG__URL=postgres://postgres:password@localhost:5432/bidding_app
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -25,6 +25,10 @@ tokio-postgres = "0.7.12"
 utoipa = "5.2.0"
 utoipa-actix-web = "0.1.2"
 utoipa-swagger-ui = { version = "8.0.3", features = ["actix-web"] }
+opentelemetry = "0.16.0"
+opentelemetry-aws = "0.16.0"
+tracing = "0.1.26"
+tracing-subscriber = "0.2.25"
 
 [[bin]]
 name = "bidding_app"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -25,10 +25,12 @@ tokio-postgres = "0.7.12"
 utoipa = "5.2.0"
 utoipa-actix-web = "0.1.2"
 utoipa-swagger-ui = { version = "8.0.3", features = ["actix-web"] }
-opentelemetry = "0.16.0"
-opentelemetry-aws = "0.16.0"
-tracing = "0.1.26"
-tracing-subscriber = "0.2.25"
+opentelemetry = "0.27.1"
+opentelemetry-aws = "0.15.0"
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"
+tracing-actix-web = "0.7.15"
+opentelemetry_sdk = "0.27.1"
 
 [[bin]]
 name = "bidding_app"

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1,8 +1,10 @@
 use deadpool_postgres::Client;
 use tokio_pg_mapper::FromTokioPostgresRow;
+use tracing::instrument;
 
 use crate::{errors::MyError, models::User};
 
+#[instrument]
 pub async fn get_users(client: &Client) -> Result<Vec<User>, MyError> {
     let stmt = include_str!("sql/get_users.sql");
     let stmt = stmt.replace("$table_fields", &User::sql_table_fields());
@@ -18,6 +20,7 @@ pub async fn get_users(client: &Client) -> Result<Vec<User>, MyError> {
     Ok(results)
 }
 
+#[instrument]
 pub async fn add_user(client: &Client, user_info: User) -> Result<User, MyError> {
     let _stmt = include_str!("sql/add_user.sql");
     let _stmt = _stmt.replace("$table_fields", &User::sql_table_fields());

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,11 +1,10 @@
-use std::env;
-
 use actix_web::middleware::Logger;
 use actix_web::{web, App, Error, HttpResponse, HttpServer};
 use confik::{Configuration as _, EnvSource};
 use deadpool_postgres::{Client, Pool};
 use dotenvy::dotenv;
 use env_logger::Env;
+use std::env;
 use tokio_postgres::NoTls;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -19,7 +18,6 @@ mod models;
 mod tracing;
 
 use self::{errors::MyError, models::User};
-use tracing::{instrument, Instrument};
 
 #[utoipa::path(
     get,
@@ -74,7 +72,7 @@ async fn main() -> std::io::Result<()> {
     let pool = config.pg.create_pool(None, NoTls).unwrap();
     env_logger::init_from_env(Env::default().default_filter_or("info"));
 
-    tracing::init_tracer();
+    tracing::init_tracer(config);
 
     let server = HttpServer::new(move || {
         App::new()

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -80,6 +80,7 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .app_data(web::Data::new(pool.clone()))
             .wrap(Logger::default())
+            .wrap(tracing_actix_web::TracingLogger::default())
             .service(
                 web::resource("/users/v1")
                     .route(web::post().to(add_user))

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -4,6 +4,7 @@ use utoipa::ToSchema;
 
 #[derive(Deserialize, PostgresMapper, Serialize, ToSchema)]
 #[pg_mapper(table = "users")] // singular 'user' is a keyword..
+#[derive(Debug)]
 pub struct User {
     pub email: String,
     pub username: String,

--- a/backend/src/tracing.rs
+++ b/backend/src/tracing.rs
@@ -1,0 +1,26 @@
+use opentelemetry::sdk::trace as sdktrace;
+use opentelemetry::sdk::Resource;
+use opentelemetry::KeyValue;
+use opentelemetry_aws::trace::XrayPropagator;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::Registry;
+
+pub fn init_tracer() -> sdktrace::Tracer {
+    let exporter = opentelemetry_aws::new_pipeline()
+        .with_service_name("bidding_app")
+        .install_batch(opentelemetry::runtime::Tokio)
+        .expect("Error initializing AWS X-Ray exporter");
+
+    let tracer = sdktrace::Tracer::builder()
+        .with_exporter(exporter)
+        .with_resource(Resource::new(vec![KeyValue::new("service.name", "bidding_app")]))
+        .build();
+
+    let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+    let subscriber = Registry::default().with(telemetry);
+    tracing::subscriber::set_global_default(subscriber).expect("Error setting global subscriber");
+
+    opentelemetry::global::set_text_map_propagator(XrayPropagator::default());
+
+    tracer
+}


### PR DESCRIPTION
Add OpenTelemetry tracing to the Rust backend to trace HTTP requests, responses, internal function calls, and database transactions.

* **Initialize Tracer:**
  - Add `backend/src/tracing.rs` to initialize the OpenTelemetry tracer using `XrayPropagator`.
  - Remove the `init_tracer` function from `backend/src/main.rs` and import it from `backend/src/tracing.rs`.
  - Initialize the OpenTelemetry tracer in the `main` function of `backend/src/main.rs`.

* **Instrument HTTP Requests and Responses:**
  - Add tracing spans to the `get_users` and `add_user` functions in `backend/src/main.rs`.

* **Instrument Database Transactions:**
  - Add tracing spans to the `get_users` and `add_user` functions in `backend/src/db.rs`.

* **Add Dependencies:**
  - Add `opentelemetry`, `opentelemetry-aws`, and `tracing` dependencies to `backend/Cargo.toml`.

* **Environment Configuration:**
  - Add `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to `backend/.env.dev`.

* **Docker Configuration:**
  - Add OTel collector and Jaeger services to `.devcontainers/docker-compose.yml`.
  - Create `otel-collector-config.yaml` in the `.devcontainers` directory with the necessary configuration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tomMoulard/Yes/pull/6?shareId=cd554d05-1211-4375-a7a2-946ba1dcc536).