### PR TITLE
Add register and login endpoints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,9 +27,6 @@ jobs:
     - name: Install rustfmt
       run: rustup component add rustfmt
 
-    - name: openapi
-      run: make openapi
-
     - name: Build
       run: cargo build --verbose
 
@@ -41,3 +38,8 @@ jobs:
 
     - name: Format
       run: cargo fmt -- --check
+
+    - name: openapi
+      run: |
+        make openapi
+        git diff --exit-code

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -13,34 +13,6 @@
     "version": "0.1.0"
   },
   "paths": {
-    "/register": {
-      "post": {
-        "tags": [],
-        "operationId": "register_user",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/User"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Register a new user",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/login": {
       "post": {
         "tags": [],
@@ -59,7 +31,7 @@
           "200": {
             "description": "Login a user",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "type": "string"
                 }
@@ -75,7 +47,7 @@
         "operationId": "refresh_token",
         "requestBody": {
           "content": {
-            "application/json": {
+            "text/plain": {
               "schema": {
                 "type": "string"
               }
@@ -87,7 +59,35 @@
           "200": {
             "description": "Refresh JWT token",
             "content": {
-              "application/json": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/register": {
+      "post": {
+        "tags": [],
+        "operationId": "register_user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Register a new user",
+            "content": {
+              "text/plain": {
                 "schema": {
                   "type": "string"
                 }

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -13,29 +13,10 @@
     "version": "0.1.0"
   },
   "paths": {
-    "/users/v1": {
-      "get": {
-        "tags": [],
-        "operationId": "get_users",
-        "responses": {
-          "200": {
-            "description": "List all users",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/User"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
+    "/register": {
       "post": {
         "tags": [],
-        "operationId": "add_user",
+        "operationId": "register_user",
         "requestBody": {
           "content": {
             "application/json": {
@@ -48,11 +29,67 @@
         },
         "responses": {
           "200": {
-            "description": "Add a new user",
+            "description": "Register a new user",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/User"
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/login": {
+      "post": {
+        "tags": [],
+        "operationId": "login_user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Login a user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/refresh": {
+      "post": {
+        "tags": [],
+        "operationId": "refresh_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Refresh JWT token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -1,6 +1,6 @@
 use jsonwebtoken::{encode, decode, Header, Validation, EncodingKey, DecodingKey};
 use serde::{Serialize, Deserialize};
-use std::time::{SystemTime, UNIX_EPOCH, Duration};
+use std::time::{SystemTime, UNIX_EPOCH};
 use crate::models::User;
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -1,7 +1,7 @@
-use jsonwebtoken::{encode, decode, Header, Validation, EncodingKey, DecodingKey};
-use serde::{Serialize, Deserialize};
-use std::time::{SystemTime, UNIX_EPOCH};
 use crate::models::User;
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {
@@ -17,7 +17,8 @@ pub fn generate_jwt(user: &User) -> String {
     let expiration = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
-        .as_secs() + 3600; // 1 hour expiration
+        .as_secs()
+        + 3600; // 1 hour expiration
 
     let claims = Claims {
         sub: user.email.clone(),
@@ -26,20 +27,35 @@ pub fn generate_jwt(user: &User) -> String {
         username: user.username.clone(),
     };
 
-    encode(&Header::default(), &claims, &EncodingKey::from_secret(SECRET)).unwrap()
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(SECRET),
+    )
+    .unwrap()
 }
 
 pub fn validate_jwt(token: &str) -> bool {
-    decode::<Claims>(token, &DecodingKey::from_secret(SECRET), &Validation::default()).is_ok()
+    decode::<Claims>(
+        token,
+        &DecodingKey::from_secret(SECRET),
+        &Validation::default(),
+    )
+    .is_ok()
 }
 
 pub fn refresh_jwt(token: &str) -> Option<String> {
     if validate_jwt(token) {
-        if let Ok(token_data) = decode::<Claims>(token, &DecodingKey::from_secret(SECRET), &Validation::default()) {
+        if let Ok(token_data) = decode::<Claims>(
+            token,
+            &DecodingKey::from_secret(SECRET),
+            &Validation::default(),
+        ) {
             let new_expiration = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
-                .as_secs() + 3600; // 1 hour expiration
+                .as_secs()
+                + 3600; // 1 hour expiration
 
             let new_claims = Claims {
                 sub: token_data.claims.sub,
@@ -48,7 +64,14 @@ pub fn refresh_jwt(token: &str) -> Option<String> {
                 username: token_data.claims.username,
             };
 
-            return Some(encode(&Header::default(), &new_claims, &EncodingKey::from_secret(SECRET)).unwrap());
+            return Some(
+                encode(
+                    &Header::default(),
+                    &new_claims,
+                    &EncodingKey::from_secret(SECRET),
+                )
+                .unwrap(),
+            );
         }
     }
     None

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -34,21 +34,22 @@ pub fn validate_jwt(token: &str) -> bool {
 }
 
 pub fn refresh_jwt(token: &str) -> Option<String> {
-    if let Ok(token_data) = decode::<Claims>(token, &DecodingKey::from_secret(SECRET), &Validation::default()) {
-        let new_expiration = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() + 3600; // 1 hour expiration
+    if validate_jwt(token) {
+        if let Ok(token_data) = decode::<Claims>(token, &DecodingKey::from_secret(SECRET), &Validation::default()) {
+            let new_expiration = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() + 3600; // 1 hour expiration
 
-        let new_claims = Claims {
-            sub: token_data.claims.sub,
-            exp: new_expiration as usize,
-            email: token_data.claims.email,
-            username: token_data.claims.username,
-        };
+            let new_claims = Claims {
+                sub: token_data.claims.sub,
+                exp: new_expiration as usize,
+                email: token_data.claims.email,
+                username: token_data.claims.username,
+            };
 
-        Some(encode(&Header::default(), &new_claims, &EncodingKey::from_secret(SECRET)).unwrap())
-    } else {
-        None
+            return Some(encode(&Header::default(), &new_claims, &EncodingKey::from_secret(SECRET)).unwrap());
+        }
     }
+    None
 }

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -1,0 +1,54 @@
+use jsonwebtoken::{encode, decode, Header, Validation, EncodingKey, DecodingKey};
+use serde::{Serialize, Deserialize};
+use std::time::{SystemTime, UNIX_EPOCH, Duration};
+use crate::models::User;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    exp: usize,
+    email: String,
+    username: String,
+}
+
+const SECRET: &[u8] = b"secret";
+
+pub fn generate_jwt(user: &User) -> String {
+    let expiration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() + 3600; // 1 hour expiration
+
+    let claims = Claims {
+        sub: user.email.clone(),
+        exp: expiration as usize,
+        email: user.email.clone(),
+        username: user.username.clone(),
+    };
+
+    encode(&Header::default(), &claims, &EncodingKey::from_secret(SECRET)).unwrap()
+}
+
+pub fn validate_jwt(token: &str) -> bool {
+    decode::<Claims>(token, &DecodingKey::from_secret(SECRET), &Validation::default()).is_ok()
+}
+
+pub fn refresh_jwt(token: &str) -> Option<String> {
+    if let Ok(token_data) = decode::<Claims>(token, &DecodingKey::from_secret(SECRET), &Validation::default()) {
+        let new_expiration = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() + 3600; // 1 hour expiration
+
+        let new_claims = Claims {
+            sub: token_data.claims.sub,
+            exp: new_expiration as usize,
+            email: token_data.claims.email,
+            username: token_data.claims.username,
+        };
+
+        Some(encode(&Header::default(), &new_claims, &EncodingKey::from_secret(SECRET)).unwrap())
+    } else {
+        None
+    }
+}

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1,34 +1,47 @@
 use deadpool_postgres::Client;
 use tokio_pg_mapper::FromTokioPostgresRow;
+use bcrypt::{hash, verify, DEFAULT_COST};
 
-use crate::{errors::MyError, models::User};
+use crate::{errors::MyError, models::User, auth::generate_jwt};
 
-pub async fn get_users(client: &Client) -> Result<Vec<User>, MyError> {
-    let stmt = include_str!("sql/get_users.sql");
-    let stmt = stmt.replace("$table_fields", &User::sql_table_fields());
-    let stmt = client.prepare(&stmt).await.unwrap();
-
-    let results = client
-        .query(&stmt, &[])
-        .await?
-        .iter()
-        .map(|row| User::from_row_ref(row).unwrap())
-        .collect::<Vec<User>>();
-
-    Ok(results)
-}
-
-pub async fn add_user(client: &Client, user_info: User) -> Result<User, MyError> {
+pub async fn register_user(client: &Client, user_info: User) -> Result<String, MyError> {
     let _stmt = include_str!("sql/add_user.sql");
     let _stmt = _stmt.replace("$table_fields", &User::sql_table_fields());
     let stmt = client.prepare(&_stmt).await.unwrap();
 
+    let hashed_password = hash(&user_info.password, DEFAULT_COST).unwrap();
+
     client
-        .query(&stmt, &[&user_info.email, &user_info.username])
+        .query(&stmt, &[&user_info.email, &hashed_password, &user_info.username])
         .await?
         .iter()
         .map(|row| User::from_row_ref(row).unwrap())
         .collect::<Vec<User>>()
         .pop()
-        .ok_or(MyError::NotFound) // more applicable for SELECTs
+        .ok_or(MyError::NotFound)?;
+
+    let token = generate_jwt(&user_info);
+    Ok(token)
+}
+
+pub async fn login_user(client: &Client, email: &str, password: &str) -> Result<String, MyError> {
+    let stmt = include_str!("sql/get_user_by_email.sql");
+    let stmt = stmt.replace("$table_fields", &User::sql_table_fields());
+    let stmt = client.prepare(&stmt).await.unwrap();
+
+    let result = client
+        .query(&stmt, &[&email])
+        .await?
+        .iter()
+        .map(|row| User::from_row_ref(row).unwrap())
+        .collect::<Vec<User>>()
+        .pop()
+        .ok_or(MyError::NotFound)?;
+
+    if verify(password, &result.password).unwrap() {
+        let token = generate_jwt(&result.email);
+        Ok(token)
+    } else {
+        Err(MyError::NotFound)
+    }
 }

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -39,7 +39,7 @@ pub async fn login_user(client: &Client, email: &str, password: &str) -> Result<
         .ok_or(MyError::NotFound)?;
 
     if verify(password, &result.password).unwrap() {
-        let token = generate_jwt(&result.email);
+        let token = generate_jwt(&result);
         Ok(token)
     } else {
         Err(MyError::NotFound)

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1,8 +1,8 @@
+use bcrypt::{hash, verify, DEFAULT_COST};
 use deadpool_postgres::Client;
 use tokio_pg_mapper::FromTokioPostgresRow;
-use bcrypt::{hash, verify, DEFAULT_COST};
 
-use crate::{errors::MyError, models::User, auth::generate_jwt};
+use crate::{auth::generate_jwt, errors::MyError, models::User};
 
 pub async fn register_user(client: &Client, user_info: User) -> Result<String, MyError> {
     let _stmt = include_str!("sql/add_user.sql");
@@ -12,7 +12,10 @@ pub async fn register_user(client: &Client, user_info: User) -> Result<String, M
     let hashed_password = hash(&user_info.password, DEFAULT_COST).unwrap();
 
     client
-        .query(&stmt, &[&user_info.email, &hashed_password, &user_info.username])
+        .query(
+            &stmt,
+            &[&user_info.email, &hashed_password, &user_info.username],
+        )
         .await?
         .iter()
         .map(|row| User::from_row_ref(row).unwrap())

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -16,39 +16,58 @@ mod config;
 mod db;
 mod errors;
 mod models;
+mod auth;
 
 use self::{errors::MyError, models::User};
 
 #[utoipa::path(
-    get,
-    path = "/users/v1",
-    responses((status = 200, description = "List all users", body = [User]))
-)]
-pub async fn get_users(db_pool: web::Data<Pool>) -> Result<HttpResponse, Error> {
-    let client: Client = db_pool.get().await.map_err(MyError::PoolError)?;
-    let users = db::get_users(&client).await?;
-    Ok(HttpResponse::Ok().json(users))
-}
-
-#[utoipa::path(
     post,
-    path = "/users/v1",
+    path = "/register",
     request_body = User,
-    responses((status = 200, description = "Add a new user", body = User))
+    responses((status = 200, description = "Register a new user", body = String))
 )]
-pub async fn add_user(
+pub async fn register_user(
     user: web::Json<User>,
     db_pool: web::Data<Pool>,
 ) -> Result<HttpResponse, Error> {
     let user_info: User = user.into_inner();
     let client: Client = db_pool.get().await.map_err(MyError::PoolError)?;
-    let new_user = db::add_user(&client, user_info).await?;
-    Ok(HttpResponse::Ok().json(new_user))
+    let token = db::register_user(&client, user_info).await?;
+    Ok(HttpResponse::Ok().json(token))
+}
+
+#[utoipa::path(
+    post,
+    path = "/login",
+    request_body = User,
+    responses((status = 200, description = "Login a user", body = String))
+)]
+pub async fn login_user(
+    user: web::Json<User>,
+    db_pool: web::Data<Pool>,
+) -> Result<HttpResponse, Error> {
+    let user_info: User = user.into_inner();
+    let client: Client = db_pool.get().await.map_err(MyError::PoolError)?;
+    let token = db::login_user(&client, &user_info.email, &user_info.password).await?;
+    Ok(HttpResponse::Ok().json(token))
+}
+
+#[utoipa::path(
+    post,
+    path = "/refresh",
+    request_body = String,
+    responses((status = 200, description = "Refresh JWT token", body = String))
+)]
+pub async fn refresh_token(
+    token: web::Json<String>,
+) -> Result<HttpResponse, Error> {
+    let new_token = auth::refresh_jwt(&token).ok_or(MyError::NotFound)?;
+    Ok(HttpResponse::Ok().json(new_token))
 }
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(get_users, add_user),
+    paths(register_user, login_user, refresh_token),
     components(schemas(User)),
     tags((name = "user", description = "User management endpoints"))
 )]
@@ -75,9 +94,16 @@ async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(pool.clone()))
             .wrap(Logger::default())
             .service(
-                web::resource("/users/v1")
-                    .route(web::post().to(add_user))
-                    .route(web::get().to(get_users)),
+                web::resource("/register")
+                    .route(web::post().to(register_user)),
+            )
+            .service(
+                web::resource("/login")
+                    .route(web::post().to(login_user)),
+            )
+            .service(
+                web::resource("/refresh")
+                    .route(web::post().to(refresh_token)),
             )
             .service(SwaggerUi::new("/docs/{_:.*}").url("/docs/openapi.json", ApiDoc::openapi()))
     })
@@ -87,9 +113,3 @@ async fn main() -> std::io::Result<()> {
 
     server.await
 }
-
-// TODO:
-// - JWT
-// - salt passwords in DB
-// - login/register
-// - OpenAPI

--- a/backend/src/sql/get_user_by_email.sql
+++ b/backend/src/sql/get_user_by_email.sql
@@ -1,0 +1,1 @@
+SELECT $table_fields FROM users WHERE email = $1;

--- a/backend/src/sql/schema.sql
+++ b/backend/src/sql/schema.sql
@@ -3,7 +3,7 @@ CREATE SCHEMA biding;
 
 CREATE TABLE biding.users (
 	id  BIGSERIAL PRIMARY KEY,
-	email       VARCHAR(200) NOT NULL,
+	email       VARCHAR(200) NOT NULL UNIQUE,
 	password    VARCHAR(200) NOT NULL,
 	username    VARCHAR(50) UNIQUE NOT NULL,
 	UNIQUE (username)

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -1,0 +1,63 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{test, web, App};
+    use mockall::predicate::*;
+    use mockall::*;
+    use deadpool_postgres::Client;
+    use crate::db::{register_user, login_user};
+    use crate::auth::{generate_jwt, validate_jwt, refresh_jwt};
+    use crate::models::User;
+    use crate::errors::MyError;
+
+    mock! {
+        pub Client {}
+        #[async_trait::async_trait]
+        impl deadpool_postgres::Client for Client {
+            async fn query(&self, query: &str, params: &[&(dyn tokio_postgres::types::ToSql + Sync)]) -> Result<Vec<tokio_postgres::Row>, tokio_postgres::Error>;
+        }
+    }
+
+    #[actix_rt::test]
+    async fn test_register_user() {
+        let mut mock_client = MockClient::new();
+        let user_info = User {
+            email: "test@example.com".to_string(),
+            username: "testuser".to_string(),
+            password: "password".to_string(),
+        };
+
+        mock_client
+            .expect_query()
+            .with(predicate::eq("INSERT INTO users(email, password, username) VALUES ($1, $2, $3) RETURNING *"))
+            .returning(|_, _| Ok(vec![]));
+
+        let result = register_user(&mock_client, user_info).await;
+        assert!(result.is_ok());
+    }
+
+    #[actix_rt::test]
+    async fn test_login_user() {
+        let mut mock_client = MockClient::new();
+        let user_info = User {
+            email: "test@example.com".to_string(),
+            username: "testuser".to_string(),
+            password: "password".to_string(),
+        };
+
+        mock_client
+            .expect_query()
+            .with(predicate::eq("SELECT * FROM users WHERE email = $1"))
+            .returning(|_, _| Ok(vec![user_info.clone()]));
+
+        let result = login_user(&mock_client, &user_info.email, &user_info.password).await;
+        assert!(result.is_ok());
+    }
+
+    #[actix_rt::test]
+    async fn test_refresh_token() {
+        let token = generate_jwt("test@example.com");
+        let new_token = refresh_jwt(&token).unwrap();
+        assert!(validate_jwt(&new_token));
+    }
+}


### PR DESCRIPTION
Implement user registration and login functionality with JWT token generation and validation.

* Add `backend/src/auth.rs` to handle JWT token generation, validation, and refresh.
* Modify `backend/src/db.rs`:
  - Rename `add_user` function to `register_user` and update it to hash and salt the password before storing it in the database.
  - Create a new function `login_user` to handle user login by verifying email and password.
  - Update `register_user` function to return a JWT token upon successful registration.
  - Update `login_user` function to return a JWT token upon successful login.
* Modify `backend/src/main.rs`:
  - Rename `add_user` endpoint to `register_user` and update it to accept an email and a password.
  - Remove `get_users` endpoint.
  - Add new routes for the login and token refresh endpoints.
* Modify `backend/src/sql/schema.sql` to add a unique constraint on the `email` column in the `users` table schema.
* Add `backend/src/tests.rs` to define mock implementations for the database functions and write unit tests for the `register_user`, `login_user`, and token refresh functions.
* Modify `backend/openapi.json` to update the OpenAPI documentation to include the new login, register, and token refresh endpoints, and the JWT token in the responses.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tomMoulard/Yes/pull/7?shareId=c146f39b-e5ae-4f09-8dd4-59ebf63ab84d).